### PR TITLE
Fixed f_open with FA_OPEN_APPEND

### DIFF
--- a/src/agon_machine.rs
+++ b/src/agon_machine.rs
@@ -1000,8 +1000,9 @@ impl AgonMachine {
 
                 // save the size in the FIL structure
                 let mut file_len = f.seek(SeekFrom::End(0)).unwrap();
-                if (mode & mos::FA_SEEKEND != 0)
+                if mode & mos::FA_SEEKEND == 0 {
                     f.seek(SeekFrom::Start(0)).unwrap();
+                }
 
                 // XXX don't support files larger than 512KiB
                 file_len = file_len.min(1<<19);
@@ -1020,7 +1021,6 @@ impl AgonMachine {
                     _ => cpu.state.reg.set24(Reg16::HL, 1)
                 }
             }
-
         }
         Environment::new(&mut cpu.state, self).subroutine_return();
     }

--- a/src/agon_machine.rs
+++ b/src/agon_machine.rs
@@ -1000,7 +1000,8 @@ impl AgonMachine {
 
                 // save the size in the FIL structure
                 let mut file_len = f.seek(SeekFrom::End(0)).unwrap();
-                f.seek(SeekFrom::Start(0)).unwrap();
+                if (mode & mos::FA_SEEKEND != 0)
+                    f.seek(SeekFrom::Start(0)).unwrap();
 
                 // XXX don't support files larger than 512KiB
                 file_len = file_len.min(1<<19);

--- a/src/mos.rs
+++ b/src/mos.rs
@@ -21,7 +21,8 @@ pub const FILINFO_MEMBER_FNAME_256BYTES: u32 = 22;
 pub const FA_WRITE: u32 = 2;
 pub const FA_CREATE_NEW: u32 = 4;
 pub const FA_CREATE_ALWAYS: u32 = 8;
-pub const FA_SEEK_END: u32 = 0x20;
+pub const FA_SEEKEND: u32 = 0x20;
+
 #[derive(Clone, Default)]
 pub struct MosMap {
     pub f_chdir: u32,

--- a/src/mos.rs
+++ b/src/mos.rs
@@ -21,7 +21,7 @@ pub const FILINFO_MEMBER_FNAME_256BYTES: u32 = 22;
 pub const FA_WRITE: u32 = 2;
 pub const FA_CREATE_NEW: u32 = 4;
 pub const FA_CREATE_ALWAYS: u32 = 8;
-
+pub const FA_SEEK_END: u32 = 0x20;
 #[derive(Clone, Default)]
 pub struct MosMap {
     pub f_chdir: u32,


### PR DESCRIPTION
Behaviour different than FatFS. When opening with FA_OPEN_APPEND the filepointer should stay at the tail of the file. Not move back to the beginning. Now fixed, tested and merged with main.